### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0](https://github.com/dvdplm/crypto-bigint-asm/releases/tag/v0.1.0) - 2025-05-20
+
+### Other
+
+- Use macos-latest ([#4](https://github.com/dvdplm/crypto-bigint-asm/pull/4))
+- Add a changelog
+- more README
+- Check for github-actions updates once per week
+- Add license and description keys
+- add README
+- Initial commit
+
 ### Added
 
 ### Changed


### PR DESCRIPTION



## 🤖 New release

* `crypto-bigint-asm`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/dvdplm/crypto-bigint-asm/releases/tag/v0.1.0) - 2025-05-20

### Other

- Use macos-latest ([#4](https://github.com/dvdplm/crypto-bigint-asm/pull/4))
- Add a changelog
- more README
- Check for github-actions updates once per week
- Add license and description keys
- add README
- Initial commit

### Added

### Changed

### Fixed
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).